### PR TITLE
Fix glob patterns to only match .ts and .js files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -190,11 +190,11 @@ export class ParseFunctionsPlugin implements WebpackPluginInstance {
       const configPath = path.join(servicePath, 'config.ts');
       const schema: ParseFunctionServiceSchema = JSON.parse(fs.readFileSync(schemaPath, { encoding: 'utf-8' }));
       const config = fs.existsSync(configPath) ? configPath.replace(this.basePath!, '..') : undefined;
-      const triggers = glob.sync(`${servicePath}/triggers/*`);
-      const functions = glob.sync(`${servicePath}/functions/**/*`);
-      const jobs = glob.sync(`${servicePath}/jobs/**/*`);
+      const triggers = glob.sync(`${servicePath}/triggers/*.{ts,js}`);
+      const functions = glob.sync(`${servicePath}/functions/**/*.{ts,js}`);
+      const jobs = glob.sync(`${servicePath}/jobs/**/*.{ts,js}`);
       const hooks: Hooks = Object.values(HookNames).reduce((hMemo, hookName) => {
-        const hookPaths = glob.sync(`${servicePath}/${hookName}/*`);
+        const hookPaths = glob.sync(`${servicePath}/${hookName}/*.{ts,js}`);
         const hookConfig = hookPaths.find((path) => /\/config\.t|js$/.test(path));
         if (hookConfig) {
           hookPaths.splice(hookPaths.indexOf(hookConfig), 1);


### PR DESCRIPTION
## Summary
- Restrict glob patterns for triggers, functions, jobs, and hooks to only match `.ts` and `.js` files
- Previously, wildcards like `functions/**/*` matched all files including `.md` files, causing webpack build failures when non-source files existed in function directories

## Test plan
- [x] Verified webpack build succeeds with CLAUDE.md files present in function directories
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)